### PR TITLE
added screenshots, improved report, disabled console output

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ This is a Selenium with RestAssured Automation framework just in case I need to 
 - MSEdge Web Driver
 - JUnit
 - Extent Reports
+
+⚠️ This framework uses Rest Assured. By default, every request response is printed out to console. To avoid this, I disabled console output in `MyTestListener`. More details in there. Take into account if you want to print to debug, you'll have to disable this, but if you do this your print would be mixed along with lots of requests responses. In a real life scenario with hundreds of tests this would be unreadable.

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <allure.version>2.25.0</allure.version>
+        <allure.version>2.29.1</allure.version>
         <aspectj.version>1.9.24</aspectj.version>
     </properties>
 
@@ -113,6 +113,13 @@
             <artifactId>annotations</artifactId>
             <version>26.0.2</version>
             <scope>compile</scope>
+        </dependency>
+
+        <!-- I imported this only to prevent an warn message regarding slf4j -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.5</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/utils/APIHandler.java
+++ b/src/main/java/utils/APIHandler.java
@@ -3,16 +3,18 @@ package utils;
 import io.qameta.allure.Step;
 import io.qameta.allure.restassured.AllureRestAssured;
 import io.restassured.response.Response;
+import java.io.PrintStream;
 
 import static io.restassured.RestAssured.given;
 
 public class APIHandler {
 
-    @Step("Get endpoint")
+    @Step("Get request")
     public static Response getEndpoint(String endpoint){
         Response res = given()
                 .filter(new AllureRestAssured())
                 .get(endpoint);
         return res;
     }
+
 }

--- a/src/test/java/api_and_selenium/APIWithSeleniumTests.java
+++ b/src/test/java/api_and_selenium/APIWithSeleniumTests.java
@@ -2,16 +2,15 @@ package api_and_selenium;
 
 import POM.MainPage;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.openqa.selenium.devtools.v135.network.model.Request;
 import support.MyAssert;
 import utils.APIHandler;
-
 import java.util.List;
 
+//Selenium Test Classes must have this tag, MyTestListener will use it to take SS when it FAILS
+@Tag("selenium")
 public class APIWithSeleniumTests extends BaseSeleniumTest {
 
     @Test
@@ -29,6 +28,12 @@ public class APIWithSeleniumTests extends BaseSeleniumTest {
     public void validateMainPageTitle(){
         MainPage mainPage = new MainPage(getDriver());
         String pageTitle = mainPage.getPageTitle();
-        MyAssert.verifyText("conduit",pageTitle);
+        MyAssert.verifyTextAreEquals("conduit",pageTitle);
+    }
+
+    @Test
+    @DisplayName("Failed test, must take screenshot")
+    public void failTestMustTakeScreenshot(){
+        MyAssert.verifyTextAreEquals("2","eee3");
     }
 }

--- a/src/test/java/api_and_selenium/BaseSeleniumTest.java
+++ b/src/test/java/api_and_selenium/BaseSeleniumTest.java
@@ -1,13 +1,20 @@
 package api_and_selenium;
+
 import POM.BasePage;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.openqa.selenium.WebDriver;
+import support.MyScreenshotHelper;
 import utils.DriverManager;
 import utils.Logger;
 
 public class BaseSeleniumTest {
 
     private WebDriver driver;
+
+    @RegisterExtension //Required to register the Context and the Driver to be used by MyScreenshotHelper
+    MyScreenshotHelper screenshotManager = new MyScreenshotHelper(
+            c -> getDriver());
 
     @BeforeEach
     public void navigateToWebsiteToTest(TestInfo testInfo){

--- a/src/test/java/support/CustomPrintStream.java
+++ b/src/test/java/support/CustomPrintStream.java
@@ -1,0 +1,16 @@
+package support;
+
+import java.io.OutputStream;
+import java.io.PrintStream;
+
+public class CustomPrintStream extends PrintStream {
+
+    public CustomPrintStream() {
+        super(new OutputStream() {
+            @Override
+            public void write(int b) {
+                // Do nothing, effectively discarding the output
+            }
+        });
+    }
+}

--- a/src/test/java/support/MyAssert.java
+++ b/src/test/java/support/MyAssert.java
@@ -29,8 +29,14 @@ public class MyAssert {
         assertEquals(apiTags,pageTags);
     }
 
+    //TODO: See https://github.com/fragsman/rest-assured-framework/issues/3
     @Step("Verify two texts")
-    public static void verifyText(String expected, String actual){
+    public static void verifyTextAreEquals(String expected, String actual){
+        assertEquals("'"+expected+"'", "'"+actual+"'");
+    }
+
+    @Step("Verify two numbers")
+    public static void verifyNumbersAreEquals(Integer expected, Integer actual){
         assertEquals(expected, actual);
     }
 }

--- a/src/test/java/support/MyScreenshotHelper.java
+++ b/src/test/java/support/MyScreenshotHelper.java
@@ -1,0 +1,37 @@
+package support;
+
+import io.qameta.allure.Allure;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
+import java.io.ByteArrayInputStream;
+import java.util.Objects;
+import java.util.function.Function;
+
+public class MyScreenshotHelper  implements TestExecutionExceptionHandler {
+
+    private final Function<ExtensionContext, WebDriver> driverSupplier;
+
+    public MyScreenshotHelper(Function<ExtensionContext, WebDriver> driverSupplier) {
+        this.driverSupplier = driverSupplier;
+    }
+
+    //Whenever an exception is raised (usually when test fails) this method will intercept it and take a screenshot
+    @Override
+    public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
+        final WebDriver webDriver = this.driverSupplier.apply(context);
+        if (Objects.nonNull(webDriver)) {
+            final String attachmentName = "Screenshot on failure (" + throwable.getClass().getSimpleName() + ")";
+            attachPageScreenshot(webDriver, attachmentName);
+        }
+
+        throw throwable;
+    }
+
+    public void attachPageScreenshot(WebDriver webDriver, String name) {
+        byte[] screenshotBytes = ((TakesScreenshot) webDriver).getScreenshotAs(OutputType.BYTES);
+        Allure.attachment(name, new ByteArrayInputStream(screenshotBytes));
+    }
+}

--- a/src/test/java/support/MyTestListener.java
+++ b/src/test/java/support/MyTestListener.java
@@ -6,18 +6,44 @@ import org.junit.platform.launcher.TestPlan;
 import utils.EnvironmentManager;
 import utils.Logger;
 
+import java.io.PrintStream;
+
 public class MyTestListener implements TestExecutionListener {
+
+    private static PrintStream originalOut;
+    private static PrintStream originalErr;
 
     @Override
     public void testPlanExecutionStarted(TestPlan testPlan){
         Logger.initLogFile();
         Logger.Info("testPlanExecutionStarted: Setting base URI for Rest Assured");
         RestAssured.baseURI = EnvironmentManager.getInstance().getBaseUri();
+        disableConsoleOutput();
     }
-
 
     public void testPlanExecutionFinished(TestPlan testPlan) {
         Logger.Info("testPlanExecutionFinished: Closing log writer");
         Logger.closeWriter();
+        enableConsoleOutput();
+    }
+
+    /**
+     * This is a force measure. I will disable all System.out and System.err messages
+     * to avoid RestAssured from printing out to console everytime it makes a request
+     * or receives a response. It is annoying and make debugging harder.
+     */
+    private static void disableConsoleOutput(){
+        originalOut = System.out;
+        originalErr = System.err;
+        System.setOut(new CustomPrintStream()); // Redirect System.out to a null stream
+        System.setErr(new CustomPrintStream()); // Redirect System.err to a null stream
+    }
+
+    /**
+     * I'll re-enable output to console. See method above.
+     */
+    private static void enableConsoleOutput(){
+        System.setOut(originalOut); // Restore original System.out
+        System.setErr(originalErr); // Restore original System.err
     }
 }


### PR DESCRIPTION
- Added MyScreenshotHelper to intercept exceptions and taking screenshot (this functionality is provided by JUnit5)
- Screenshots are added for Selenium Tests (it only make sense for them and not API tests as there is no WebDriver or Screen to capture)
- Disabled output to console to avoid RestAssured to print every request response to the console output because it would be very long output and make it extremely hard to debug in case I need it. This is done intercepting outputs in CustumPrintStream class and making use of it in MyTestListener.